### PR TITLE
Fix to_bytes in fips204.py

### DIFF
--- a/fips204.py
+++ b/fips204.py
@@ -174,7 +174,7 @@ class ML_DSA:
             self.__init__(param)
         # print('# keygen_internal()', param)
         # print('# seed:', xi.hex())
-        se = self.h(xi + self.k.to_bytes() + self.ell.to_bytes(), 128)
+        se = self.h(xi + self.integer_to_bytes(self.k, 1) + self.integer_to_bytes(self.ell, 1), 128)
         rho = se[0:32]
         rhop = se[32:96]
         kk = se[96:128]
@@ -659,7 +659,7 @@ class ML_DSA:
         a = [ [None]*self.ell for _ in range(self.k) ]
         for r in range(self.k):
             for s in range(self.ell):
-                rhop = rho + s.to_bytes() + r.to_bytes()
+                rhop = rho + self.integer_to_bytes(s, 1) + self.integer_to_bytes(r, 1)
                 a[r][s] = self.rej_ntt_poly(rhop)
         return a
 


### PR DESCRIPTION
`fips204.py` uses Python's built-in `int.to_bytes(...)` method, but does not provide the required arguments `length` and `byteorder`. This results in an exception:

```
Traceback (most recent call last):
  File "./fips204.py", line 904, in <module>
    test_mldsa( ml_dsa.keygen_internal,
  File "/home/mitch/py-acvp-pqc/test_mldsa.py", line 221, in test_mldsa
    fail += mldsa_test_keygen(keygen_kat, keygen_func, iut)
  File "/home/mitch/py-acvp-pqc/test_mldsa.py", line 45, in mldsa_test_keygen
    (pk, sk)    = keygen_func(  bytes.fromhex(x['seed']),
  File "./fips204.py", line 177, in keygen_internal
    se = self.h(xi + self.k.to_bytes() + self.ell.to_bytes(), 128)
TypeError: to_bytes() missing required argument 'length' (pos 1)
```

This change fixes the code to use the `integer_to_bytes` method that is defined as part of the ML_DSA class.

Note that the same issue exists in fips203.py, but I didn't fix that one because I'm less familiar with that algorithm.