### PR TITLE
Fix pre-hash calculation: add ctx to M'

### DIFF
--- a/fips204.py
+++ b/fips204.py
@@ -133,6 +133,7 @@ class ML_DSA:
 
         mp  = ( self.integer_to_bytes(1, 1) +
                 self.integer_to_bytes(len(ctx), 1) +
+                ctx +
                 oid + phm )
         sig = self.sign_internal(sk, mp, rnd)
         return sig
@@ -163,6 +164,7 @@ class ML_DSA:
 
         mp  = ( self.integer_to_bytes(1, 1) +
                 self.integer_to_bytes(len(ctx), 1) +
+                ctx +
                 oid + phm )
         return self.verify_internal(pk, mp, sig)
 


### PR DESCRIPTION
Per FIPS 204, M' (`mp`) should be:

M'  ← BytesToBits(IntegerToBytes(1, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥 ∥ OID ∥ PH𝑀) 

The current implementation is missing the context string. This change fixes it.

Verified changes with KATs from https://github.com/post-quantum-cryptography/KAT